### PR TITLE
Added Ctrl+Shift+Z to redo (average macOS user)

### DIFF
--- a/scratchpad.py
+++ b/scratchpad.py
@@ -283,7 +283,7 @@ class Scratchpad(QMainWindow):
         self.actions['undo'] = undoAction
 
         redoAction = QAction('Redo', self)
-        redoAction.setShortcut('Ctrl+Y')
+        redoAction.setShortcut('Ctrl+Y, Ctrl+Shift+Z')
         redoAction.triggered.connect(self.textEdit.redo)
         menu.addAction(redoAction)
         self.actions['redo'] = redoAction


### PR DESCRIPTION
# hi
well so i did this and now you can press ctrl+shift+z if you want to redo, but also if you press ctrl+y it still redoes. this is because on the operating system "macOS", made by Apple, the default key to redo in most applications in the desktop enviroment is ctrl+shift+z. some people use this on windows, me included, so thats why i made this. i hope this pull request is accepted so i didnt type this for nothing